### PR TITLE
fix: drop option for osms limiting for now

### DIFF
--- a/oci/oke-node-pool/main.tf
+++ b/oci/oke-node-pool/main.tf
@@ -15,16 +15,6 @@ chmod 600 /swapfile
 mkswap /swapfile
 swapon /swapfile
 echo '/swapfile none swap sw 0 0' >> /etc/fstab
-
-# Cap osms-agent memory so dnf is OOM-killed before Kubernetes pods are
-mkdir -p /etc/systemd/system/osms-agent.service.d
-cat > /etc/systemd/system/osms-agent.service.d/memory-limit.conf <<UNIT
-[Service]
-MemoryMax=${var.osms_memory_limit_mb}M
-MemorySwapMax=0
-UNIT
-systemctl daemon-reload
-systemctl restart osms-agent || true
 EOF
   ) : null
 

--- a/oci/oke-node-pool/terraform.md
+++ b/oci/oke-node-pool/terraform.md
@@ -44,7 +44,6 @@ No modules.
 | <a name="input_node_pool_size"></a> [node\_pool\_size](#input\_node\_pool\_size) | Node pool size | `number` | `1` | no |
 | <a name="input_node_shape"></a> [node\_shape](#input\_node\_shape) | Desired node shape | `string` | `"VM.Standard.A1.Flex"` | no |
 | <a name="input_num_ocpus"></a> [num\_ocpus](#input\_num\_ocpus) | OCPUs for each node in node pool | `number` | `1` | no |
-| <a name="input_osms_memory_limit_mb"></a> [osms\_memory\_limit\_mb](#input\_osms\_memory\_limit\_mb) | Hard memory cap (MB) applied to the osms-agent systemd service when limit\_osms\_memory is enabled. If dnf exceeds this, the OS kills dnf rather than pods. | `number` | `512` | no |
 | <a name="input_osms_swap_size_gb"></a> [osms\_swap\_size\_gb](#input\_osms\_swap\_size\_gb) | Size in GB of the swap file created on each node when limit\_osms\_memory is enabled. | `number` | `2` | no |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | Full SSH public key | `string` | n/a | yes |
 | <a name="input_tenancy_ocid"></a> [tenancy\_ocid](#input\_tenancy\_ocid) | Tenancy OCID, for image lookup | `string` | n/a | yes |

--- a/oci/oke-node-pool/variables.tf
+++ b/oci/oke-node-pool/variables.tf
@@ -121,17 +121,6 @@ variable "osms_swap_size_gb" {
   }
 }
 
-variable "osms_memory_limit_mb" {
-  type        = number
-  default     = 512
-  description = "Hard memory cap (MB) applied to the osms-agent systemd service when limit_osms_memory is enabled. If dnf exceeds this, the OS kills dnf rather than pods."
-
-  validation {
-    condition     = var.osms_memory_limit_mb >= 256 && var.osms_memory_limit_mb <= 4096
-    error_message = "osms_memory_limit_mb must be between 256 and 4096."
-  }
-}
-
 variable "node_metadata" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
```cloud-init[4818]: Failed to restart osms-agent.service: Unit osms-agent.service not found```