### PR TITLE
chore: remove Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "terraform"
-    directory: "terraform"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Removes `.github/dependabot.yml`. Dependency updates are consolidated on Renovate via GitLab scheduled pipelines; Dependabot is being retired across the org.