### PR TITLE
ci: add a CI result gate, so the ruleset need not name the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,38 @@ jobs:
             -v "${PWD}:/workspace" -w /workspace \
             quay.io/terraform-docs/terraform-docs:0.20.0 \
             terraform-docs --output-check "${PROVIDER_DIR}/"
+
+  result:
+    name: CI result
+    # The stable name for the branch ruleset to require.
+    #
+    # The docs matrix is a literal list of provider directories, so requiring
+    # `terraform-docs (gitlab)` by name couples the ruleset to that list: a
+    # required check that never reports blocks merging indefinitely, so
+    # removing a provider directory would brick main until terraform caught
+    # up. Retiring `gitlab/` is a live prospect as the GitHub migration
+    # finishes, which makes that a real failure mode rather than a
+    # theoretical one.
+    #
+    # This job always runs and its name never changes, so the ruleset can
+    # require it and the matrix stays free to change.
+    if: always()
+    needs: [secrets, validate, docs]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Summarise
+        run: |
+          echo "secrets:  ${{ needs.secrets.result }}"
+          echo "validate: ${{ needs.validate.result }}"
+          echo "docs:     ${{ needs.docs.result }}"
+
+      - name: Fail if any job failed
+        if: >-
+          needs.secrets.result == 'failure' || needs.secrets.result == 'cancelled' ||
+          needs.validate.result == 'failure' || needs.validate.result == 'cancelled' ||
+          needs.docs.result == 'failure' || needs.docs.result == 'cancelled'
+        run: |
+          echo "::error::One or more CI jobs did not pass."
+          exit 1


### PR DESCRIPTION
Groundwork for putting `required_status_checks` on this repo's ruleset — it has none today, so CI reports and nothing blocks a merge.

The obvious move is to require the checks by name:

```
Terraform fmt and validate
terraform-docs (cloudflare)
terraform-docs (discord)
terraform-docs (github)
terraform-docs (gitlab)
terraform-docs (kubernetes)
terraform-docs (oci)
```

That couples the ruleset, which lives in `terraform/infra/repos.tf`, to a literal matrix list in this file. GitHub's docs are explicit that a required check which never reports *"stay[s] in a 'Pending' state and block[s] merging"* — so deleting a provider directory would brick `main` here until someone edited the other repo, with no error pointing at why.

Retiring `gitlab/` is a live prospect once the GitHub migration finishes, so that is the actual sequence, not a hypothetical.

This adds one `if: always()` job whose name is stable regardless of the matrix, failing when `secrets`, `validate` or `docs` failed or was cancelled. The ruleset can then require **`CI result`** alone, and the matrix stays free to change.

Mirrors tnoff/github-workflows#39, which does the same for the tox matrix.

`pre-commit run` clean; `actionlint` clean with `shellcheck` on PATH — this repo has no actionlint hook, so I ran it directly rather than assuming the hook covered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbM8bWcpX1HhsM88B2UmqN
