### PR TITLE
chore(ci): bump github-workflows pin to 3326ac2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   secrets:
     name: Scan for secrets
-    uses: tnoff/github-workflows/.github/workflows/trufflehog.yml@c97852c991d7a4562844df68ab16717dfda54dd7
+    uses: tnoff/github-workflows/.github/workflows/trufflehog.yml@3326ac29c672f67bce33272b3a09fe06c9947080
 
   # fmt + validate. Deliberately a SEPARATE JOB from docs below, and that
   # separation is load-bearing rather than tidiness: `terraform init` writes a

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   renovate:
     name: Renovate
-    uses: tnoff/github-workflows/.github/workflows/renovate.yml@c97852c991d7a4562844df68ab16717dfda54dd7
+    uses: tnoff/github-workflows/.github/workflows/renovate.yml@3326ac29c672f67bce33272b3a09fe06c9947080
     secrets:
       renovate_token: ${{ secrets.RENOVATE_TOKEN }}
 
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    uses: tnoff/github-workflows/.github/workflows/branch-cleanup.yml@c97852c991d7a4562844df68ab16717dfda54dd7
+    uses: tnoff/github-workflows/.github/workflows/branch-cleanup.yml@3326ac29c672f67bce33272b3a09fe06c9947080
     with:
       age_days: 30
       dry_run: false


### PR DESCRIPTION
Moves this repo's `tnoff/github-workflows` pin to `3326ac2`.

The change that matters in that range is **github-workflows#47**, which stops `renovate-auto-approve.yml` submitting an approving review by default.

That review satisfied no rule. `require_code_owner_review` is a sub-condition of requiring approvals, and the shared `github/repo` module leaves `required_approving_review_count` at the provider default of `0` — so there was no approval for a code owner to qualify. GitHub reported `reviewDecision: null` on affected PRs, meaning none was required to merge. What the review did do was put the repo owner's personal signature on every bot PR, and every consumer had widened `branch_pattern` from the `^renovate/dev-` default to `^renovate/`, so it landed on majors too.

**Auto-merge is unaffected.** It was previously in the same step as the approval, after the `gh pr review` call, so switching one off would have switched off the other. #47 splits them into separate steps off a shared branch-pattern gate — the required status checks were always the real gate.

Opened by hand rather than waiting for Renovate: the pins are spread across four SHAs, and until each moves, that repo keeps approving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbM8bWcpX1HhsM88B2UmqN
